### PR TITLE
Add build system deps and update setup.py metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,6 @@ typings/
 # User-specific stuff
 .idea/
 
-
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -264,3 +263,19 @@ $RECYCLE.BIN/
 
 # End of https://www.gitignore.io/api/node,linux,macos,python,pycharm,windows,visualstudiocode
 
+# common python vitrual environment names
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+miniconda3/
+
+# jupyter notebook checkpoints
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0rc15,==3.*", "setuptools>=40.8.0", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-hs-restclient
-jupyter
-notebook
-requests

--- a/setup.py
+++ b/setup.py
@@ -1,53 +1,75 @@
 """
-This file installs the hydroshare_jupyter_sync package on your computer.
-It can be used as a jupyter server extension to launch the sync web app for
-syncing files between HydroShare and JupyterHub.
-
 Author: 2019-20 CUAHSI Olin SCOPE Team
 Vicky McDermott, Kyle Combes, Emily Lepert, and Charlie Weiss
+
+Maintainer: Austin Raney
+Maintainer Email: araney@cuahsi.org
+Maintainer Affiliation: CUAHSI
 """
+# TODO: add citation
 import os
 import sys
 import glob
 import shutil
-import pathlib
-import setuptools
+from pathlib import Path
 import subprocess
-from setuptools import Command
+from setuptools import Command, setup, find_packages
 from setuptools.command.install import install
 
 # define package name globally
-pkgname = 'hydroshare_jupyter_sync'
+PKGNAME = "hydroshare_jupyter_sync"
+VERSION = "0.1.2"
 
 # define webapp path globally
-here = str(pathlib.Path(__file__).parent.absolute())
-webpath = os.path.join(here, 'webapp')
+here = Path(__file__).resolve().parent.absolute()
+webpath = here / "webapp"
 
-# read the requirements file and pass lib names to setuptools
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+# Package author information
+AUTHOR = "CUAHSI"
+AUTHOR_EMAIL = "scope-cuahsi@olin.edu"
+
+MAINTAINER = "Austin Raney"
+MAINTAINER_EMAIL = "araney@cuahsi.org"
+
+# package version requirement
+PYTHON_REQUIRES = ">=3.7"
+
+# Package dependency requirements
+REQUIREMENTS = [
+    "hs-restclient",
+    "jupyterlab",
+    "notebook",
+    "requests",
+]
+
+# Development requirements
+DEVELOPMENT_REQUIREMENTS = ["pytest"]
+
+SHORT_DESCRIPTION = "A web app and server for syncing files between the local filesystem and HydroShare. Can run as a Jupyter notebook extension."
+
+# Long description
+with (Path(__file__).parent / "README.md").open("r") as f:
+    LONG_DESCRIPTION = f.read()
 
 
 def run_command(command, cwd):
-    process = subprocess.Popen(command,
-                               cwd=cwd,
-                               stdout=subprocess.PIPE)
+    process = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE)
     for line in process.stdout:
-        sys.stdout.write(line.decode('utf-8'))
+        sys.stdout.write(line.decode("utf-8"))
 
 
 class build_react(install):
     def run(self):
         # build and install the Sync Webapp
-        cmd = ['yarn', 'install']
+        cmd = ["yarn", "install"]
         run_command(cmd, cwd=webpath)
 
-        cmd = ['yarn', 'build']
+        cmd = ["yarn", "build"]
         run_command(cmd, cwd=webpath)
 
         # move files to python build dir
-        assets = os.path.join(webpath, 'public', 'assets')
-        target_path = os.path.join(os.getcwd(), pkgname, 'assets')
+        assets = os.path.join(webpath, "public", "assets")
+        target_path = os.path.join(os.getcwd(), PKGNAME, "assets")
         if os.path.exists(target_path):
             shutil.rmtree(target_path)
         shutil.copytree(assets, target_path)
@@ -55,13 +77,16 @@ class build_react(install):
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""
-    CLEAN_FILES = ['./build',
-                   './dist',
-                   './*.pyc',
-                   './*.tgz',
-                   './*.egg-info',
-                   './webapp/build',
-                   './webapp/node_modules']
+
+    CLEAN_FILES = [
+        "./build",
+        "./dist",
+        "./*.pyc",
+        "./*.tgz",
+        "./*.egg-info",
+        "./webapp/build",
+        "./webapp/node_modules",
+    ]
 
     user_options = []
 
@@ -75,34 +100,35 @@ class CleanCommand(Command):
 
         for path_spec in self.CLEAN_FILES:
             # Make paths absolute and relative to this path
-            abs_paths = glob.glob(os.path.normpath(
-                                            os.path.join(here, path_spec)))
+            abs_paths = glob.glob(os.path.normpath(os.path.join(here, path_spec)))
             for path in [str(p) for p in abs_paths]:
                 if not path.startswith(here):
                     # Die if path in CLEAN_FILES is absolute
                     # + outside this directory
-                    raise (ValueError)("%s is not a path inside %s"
-                                       % (path, here))
-                print('removing %s' % os.path.relpath(path))
+                    raise (ValueError)("%s is not a path inside %s" % (path, here))
+                print("removing %s" % os.path.relpath(path))
                 shutil.rmtree(path)
 
 
-# standard setuptools args
-setuptools.setup(
+setup(
     cmdclass={
-        'build_react': build_react,
-        'clean': CleanCommand,
-        },
-    name=pkgname,
-    version='0.1.2',
-    author='CUAHSI',
-    author_email='scope-cuahsi@olin.edu',
-    packages=setuptools.find_packages(),
-    url='https://github.com/hydroshare/hydroshare_jupyter_sync',
-    license='',
-    description='A web app and server for syncing files between the local '
-                'filesystem and HydroShare. Can run as a'
-                ' Jupyter notebook extension.',
+        "build_react": build_react,
+        "clean": CleanCommand,
+    },
+    name=PKGNAME,
+    version=VERSION,
+    python_requires=PYTHON_REQUIRES,
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    maintainer=MAINTAINER,
+    maintainer_email=MAINTAINER_EMAIL,
+    packages=find_packages(),
+    url="https://github.com/hydroshare/hydroshare_jupyter_sync",
+    license="",
+    description=SHORT_DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     include_package_data=True,
-    install_requires=required,
+    install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )


### PR DESCRIPTION
## Additions

- Austin Raney (@aaraney) added to package maintainer role.
- `develop` extra_require directive added to install unit testing deps. Usage: `pip install ".[develop]"`

## Removals

- `requirements.txt` removed

## Changes

- Dependencies are now explicitly listed in `setup.py` instead of `requirements.txt`.
- Package python requries version >= 3.7. Python 3.6 is EOL in December 2021.