### PR TITLE
Add mechanism to login to HydroShare via OAuth2. Adds backend and frontend support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include hydroshare_jupyter_sync/assets/*
-include hydroshare_jupyter_sync/labextension/*
+recursive-include hydroshare_jupyter_sync/labextension *

--- a/hydroshare_jupyter_sync/__init__.py
+++ b/hydroshare_jupyter_sync/__init__.py
@@ -3,6 +3,8 @@ Setup jupyterlab server and lab extensions. Add tornado HTTP handlers to jupyter
 """
 import json
 from pathlib import Path
+from jupyter_server.serverapp import ServerApp
+from jupyter_server.utils import url_path_join
 
 # local imports
 from .config_setup import ConfigFile
@@ -12,7 +14,6 @@ from .handlers import get_route_handlers
 FRONTEND_PATH = "/sync"
 BACKEND_PATH = "/syncApi"
 
-MODULE_NAME = "hydroshare_jupyter_sync"
 EXTENSION_DIRNAME = "labextension"
 
 PARENT_DIR = Path(__file__).parent.resolve()
@@ -20,17 +21,26 @@ EXTENSION_METADATA_PATH = PARENT_DIR / f"{EXTENSION_DIRNAME}/package.json"
 
 # read metadata from js extension package metadata file, `package.json`
 extension_metadata = json.loads(EXTENSION_METADATA_PATH.read_text())
+MODULE_NAME = extension_metadata["name"]
 
 
 def _jupyter_labextension_paths():
-    return [{"src": EXTENSION_DIRNAME, "dest": extension_metadata["name"]}]
+    return [{"src": EXTENSION_DIRNAME, "dest": MODULE_NAME}]
 
 
-def _jupyter_server_extension_paths():
+# def _jupyter_server_extension_paths():
+#     return [{"module": MODULE_NAME}]
+
+
+def _jupyter_server_extension_points():
+    """
+    Returns a list of dictionaries with metadata describing
+    where to find the `_load_jupyter_server_extension` function.
+    """
     return [{"module": MODULE_NAME}]
 
 
-def _load_jupyter_server_extension(server_app):
+def _load_jupyter_server_extension(server_app: ServerApp):
     """Registers the API handler to receive HTTP requests from the frontend extension.
 
     Parameters
@@ -38,7 +48,11 @@ def _load_jupyter_server_extension(server_app):
     server_app: jupyterlab.labapp.LabApp
         JupyterLab application instance
     """
-    handlers = get_route_handlers(FRONTEND_PATH, BACKEND_PATH)
+    web_app = server_app.web_app
+    base_url = web_app.settings["base_url"]
+    handlers = get_route_handlers(
+        url_path_join(base_url, FRONTEND_PATH), url_path_join(base_url, BACKEND_PATH)
+    )
 
     # `cookie_secret` inherited from `server_app`
     server_app.web_app.add_handlers(".*$", handlers)

--- a/hydroshare_jupyter_sync/__main__.py
+++ b/hydroshare_jupyter_sync/__main__.py
@@ -1,16 +1,27 @@
 import argparse
 import logging
+import os
 import signal
 import sys
+from pathlib import Path
+
+from jupyter_core.paths import ENV_JUPYTER_PATH
+from jupyter_server.extension.serverextension import EnableServerExtensionApp
 
 from tornado import options
 from tornado import ioloop
 from tornado.web import Application
 from pathlib import Path
 from .handlers import get_route_handlers
-from .cli import parse
+from .cli import CommandNamespace, parse
 from .config_setup import ConfigFile
 
+MODULE_DIR = Path(__file__).parent.resolve()
+_ERROR_MESSAGE_PREFIX = "Fatal, cannot link labextension."
+
+# path to pre-built lab-extension
+EXTENSION_NAME = "hydroshare_jupyter_sync"
+LABEXTENSION_PATH = MODULE_DIR / "labextension"
 
 class TestApp(Application):
     """Class for setting up the server & making sure it can exit cleanly"""
@@ -40,33 +51,111 @@ def get_test_app(**settings) -> Application:
     )
 
 
-def main(parser: argparse.Namespace):
+def enable_server_extension(extension_name: str):
+    o = EnableServerExtensionApp()
+    o.toggle_server_extension(extension_name)
+
+
+def get_env_jupyter_path() -> Path:
+    """Absolute path to Jupyter's ENV_JUPYTER_PATH.
+    If multiple ENV_JUPYTER_PATH's are specified, the first is returned.
+    """
+    try:
+        return Path(ENV_JUPYTER_PATH[0]).resolve()
+    except IndexError as e:
+        error_message = f"{_ERROR_MESSAGE_PREFIX} ENV_CONFIG_PATH not set."
+        raise ValueError(error_message) from e
+
+
+def link_prebuilt_labextension(
+    labextension_name: str, labextension_prebuilt_files_dir: str
+):
+    labextension_prebuilt_files_dir = Path(labextension_prebuilt_files_dir).resolve()
+
+    # naively verify that labextension exists (does not verify contents of directory. i.e. package.json exists)
+    if (
+        not labextension_prebuilt_files_dir.exists()
+        or not labextension_prebuilt_files_dir.is_dir()
+    ):
+        error_message = f"{_ERROR_MESSAGE_PREFIX} labextension_prebuilt_files_dir: {labextension_prebuilt_files_dir} does not exist."
+        raise FileNotFoundError(error_message)
+
+    labextensions_path = get_env_jupyter_path() / "labextensions"
+
+    # create `labextensions` directory if it does not already exist. Create intermediate dirs if necessary
+    labextensions_path.mkdir(exist_ok=True, parents=True)
+
+    link_dir = labextensions_path / labextension_name
+
+    # choose not to fail raise exception if link_dir exists.
+    if link_dir.exists():
+        if link_dir.is_symlink() and os.readlink(str(link_dir)) == str(
+            labextension_prebuilt_files_dir
+        ):
+            print(f"{labextension_prebuilt_files_dir} already linked to {link_dir}")
+        else:
+            print(
+                f"Could not link {labextension_prebuilt_files_dir} to {link_dir}. {link_dir} already exists. Remove {link_dir} and reinstall."
+            )
+    else:
+        # note: target_is_directory True, required for windows support
+        link_dir.symlink_to(labextension_prebuilt_files_dir, target_is_directory=True)
+
+        print(f"{labextension_prebuilt_files_dir} linked to {link_dir}")
+
+
+def configure_jupyter() -> None:
+    # link lab extension to correct location and enable server extension
+    link_prebuilt_labextension(EXTENSION_NAME, LABEXTENSION_PATH)
+    enable_server_extension(EXTENSION_NAME)
+
+
+def start_stand_alone_session(
+    hostname: str, port: int, debug: bool, config: ConfigFile
+) -> None:
+    app = get_test_app(default_hostname=hostname, debug=debug, **config.dict())
+
+    logging.info(f"Server starting on {hostname}:{port}")
+    logging.info(f"Debugging mode {'enabled' if debug else 'disabled'}")
+
+    signal.signal(signal.SIGINT, app.signal_handler)
+    app.listen(port)
+    ioloop.PeriodicCallback(app.try_exit, 100).start()
+    ioloop.IOLoop.instance().start()
+
+
+def main(parser: argparse.Namespace) -> None:
     # clear argv. options parse command line somehow sets up logging
     # tornados logging setup is pretty broken. Do not want to pass any command line args
     # here
     sys.argv = []
     options.parse_command_line()
-    debug_enabled = not parser.no_debug
-    # TODO: write logs to file in config.log
 
-    # parse config file
-    config = (
-        ConfigFile() if parser.config is None else ConfigFile(_env_file=parser.config)
-    )
+    # command routing
+    if parser.command == CommandNamespace.configure:
+        configure_jupyter()
 
-    app = get_test_app(
-        default_hostname=parser.hostname, debug=debug_enabled, **config.dict()
-    )
+    elif parser.command == CommandNamespace.start:
+        # TODO: write logs to file in config.log
+        # parse config file
+        config = (
+            ConfigFile()
+            if parser.config is None
+            else ConfigFile(_env_file=parser.config)
+        )
 
-    logging.info(f"Server starting on {parser.hostname}:{parser.port}")
-    logging.info(f"Debugging mode {'enabled' if debug_enabled else 'disabled'}")
+        kwargs = {
+            "hostname": parser.hostname,
+            "port": parser.port,
+            "debug": not parser.debug,
+            "config": config,
+        }
 
-    signal.signal(signal.SIGINT, app.signal_handler)
-    app.listen(parser.port)
-    ioloop.PeriodicCallback(app.try_exit, 100).start()
-    ioloop.IOLoop.instance().start()
+        start_stand_alone_session(**kwargs)
 
 
 if __name__ == "__main__":
     parser = parse()
-    main(parser)
+    if len(sys.argv) <= 1:
+        parser.print_help()
+    main(parser.parse_args())

--- a/hydroshare_jupyter_sync/cli.py
+++ b/hydroshare_jupyter_sync/cli.py
@@ -4,7 +4,12 @@ from typing import Union
 from .utilities.pathlib_utils import expand_and_resolve
 
 
-def parse() -> Union[argparse.Namespace, None]:
+class CommandNamespace:
+    start: str = "start"
+    configure: str = "configure"
+
+
+def parse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hydroshare_jupyter_sync",
         description=(
@@ -21,42 +26,56 @@ def parse() -> Union[argparse.Namespace, None]:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # This adds defaults to help page
     )
 
-    parser.add_argument(
+    commands = parser.add_subparsers(title="commands", dest="command")
+    start = commands.add_parser(
+        CommandNamespace.start,
+        help="start a stand-alone instance of the backend server extension.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # This adds defaults to help page
+    )
+    commands.add_parser(
+        CommandNamespace.configure,
+        help="link hydroshare_jupyter_sync's lab and server extension with jupyter.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,  # This adds defaults to help page
+    )
+
+    start.add_argument(
         "-p",
         "--port",
         type=int,
         nargs="?",
-        help="Port number to listen on",
+        help="port number to listen on",
         default=8080,
     )
 
-    parser.add_argument(
+    start.add_argument(
         "-n",
         "--hostname",
         type=str,
         nargs="?",
-        help="HTTP Server hostname",
+        help="HTTP server hostname",
         default="127.0.0.1",  # localhost
     )
 
-    parser.add_argument(
+    # default to run in debug mode
+    start.add_argument(
         "-d",
         "--no-debug",
         action="store_true",
         default=False,
-        help="Disable debugging mode",
+        help="disable debugging mode",
+        dest="debug",
     )
 
-    parser.add_argument(
+    start.add_argument(
         "-c",
         "--config",
         nargs="?",
         type=absolute_file_path,
-        help="Path to configuration file. By default read from ~/.config/hydroshare_jupyter_sync/config then ~/.hydroshare_jupyter_sync_config if either exist.",
+        help="path to configuration file. by default read from ~/.config/hydroshare_jupyter_sync/config then ~/.hydroshare_jupyter_sync_config if either exist.",
         required=False,
     )
 
-    return parser.parse_args()
+    return parser
 
 
 def is_file_and_exists(f: Union[str, Path]) -> bool:

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -1,7 +1,9 @@
-from pydantic import BaseSettings, Field, root_validator
+from pydantic import BaseSettings, Field, root_validator, validator
+import pickle
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 from .utilities.pathlib_utils import first_existing_file, expand_and_resolve
+from .models.oauth import OAuthFile
 
 _DEFAULT_CONFIG_FILE_LOCATIONS = (
     "~/.config/hydroshare_jupyter_sync/config",
@@ -21,20 +23,33 @@ class ConfigFile(BaseSettings):
     # case-insensitive alias values DATA and LOG
     data_path: Path = Field(_DEFAULT_DATA_PATH, env="data")
     log_path: Path = Field(_DEFAULT_LOG_PATH, env="log")
+    oauth_path: Optional[OAuthFile] = Field(None, env="oauth")
 
     class Config:
         env_file: Union[str, None] = first_existing_file(_DEFAULT_CONFIG_FILE_LOCATIONS)
         env_file_encoding = "utf-8"
 
-    @root_validator
-    def create_paths_if_do_not_exist(cls, values: dict):
-        for key, path in values.items():
-            path = expand_and_resolve(path)
-            if path.is_file():
-                raise FileNotDirectoryError(
-                    f"Configuration setting: {key}={str(path)} is a file not a directory."
-                )
-            elif not path.exists():
-                path.mkdir()
+    @validator("data_path", "log_path")
+    def create_paths_if_do_not_exist(cls, v: Path):
+        # for key, path in values.items():
+        path = expand_and_resolve(v)
+        if path.is_file():
+            raise FileNotDirectoryError(
+                f"Configuration path: {str(path)} is a file not a directory."
+            )
+        elif not path.exists():
+            path.mkdir()
+        return v
 
-        return values
+    @validator("oauth_path", pre=True)
+    def unpickle_oauth_path(cls, v):
+        if v is None:
+            return
+        path = expand_and_resolve(v)
+        if not path.is_file():
+            error_message = "Provided OAUTH configuration value must be file."
+            raise FileNotFoundError(error_message)
+
+        with open(path, "rb") as f:
+            deserialized = pickle.load(f)                
+        return deserialized

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -3,7 +3,7 @@ import pickle
 from pathlib import Path
 from typing import Optional, Union
 from .utilities.pathlib_utils import first_existing_file, expand_and_resolve
-from .models.oauth import OAuthFile
+from .models.oauth import OAuthFile, OAuthContents
 
 _DEFAULT_CONFIG_FILE_LOCATIONS = (
     "~/.config/hydroshare_jupyter_sync/config",
@@ -23,7 +23,7 @@ class ConfigFile(BaseSettings):
     # case-insensitive alias values DATA and LOG
     data_path: Path = Field(_DEFAULT_DATA_PATH, env="data")
     log_path: Path = Field(_DEFAULT_LOG_PATH, env="log")
-    oauth_path: Optional[OAuthFile] = Field(None, env="oauth")
+    oauth_path: Optional[OAuthContents] = Field(None, env="oauth")
 
     class Config:
         env_file: Union[str, None] = first_existing_file(_DEFAULT_CONFIG_FILE_LOCATIONS)
@@ -51,5 +51,7 @@ class ConfigFile(BaseSettings):
             raise FileNotFoundError(error_message)
 
         with open(path, "rb") as f:
-            deserialized = pickle.load(f)                
-        return deserialized
+            deserialized_model =  pickle.load(f)                
+        model = OAuthFile.parse_obj(deserialized_model)
+
+        return model.dict()[0] # type: OAuthContents

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -23,7 +23,7 @@ class ConfigFile(BaseSettings):
     # case-insensitive alias values DATA and LOG
     data_path: Path = Field(_DEFAULT_DATA_PATH, env="data")
     log_path: Path = Field(_DEFAULT_LOG_PATH, env="log")
-    oauth_path: Optional[OAuthContents] = Field(None, env="oauth")
+    oauth_path: Optional[OAuthFile] = Field(None, env="oauth")
 
     class Config:
         env_file: Union[str, None] = first_existing_file(_DEFAULT_CONFIG_FILE_LOCATIONS)
@@ -51,7 +51,6 @@ class ConfigFile(BaseSettings):
             raise FileNotFoundError(error_message)
 
         with open(path, "rb") as f:
-            deserialized_model =  pickle.load(f)                
-        model = OAuthFile.parse_obj(deserialized_model)
+            deserialized_model = pickle.load(f)
 
-        return model.dict()[0] # type: OAuthContents
+        return OAuthFile.parse_obj(deserialized_model)

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -23,7 +23,7 @@ class ConfigFile(BaseSettings):
     # case-insensitive alias values DATA and LOG
     data_path: Path = Field(_DEFAULT_DATA_PATH, env="data")
     log_path: Path = Field(_DEFAULT_LOG_PATH, env="log")
-    oauth_path: Optional[OAuthFile] = Field(None, env="oauth")
+    oauth_path: Union[OAuthFile, str, None] = Field(None, env="oauth")
 
     class Config:
         env_file: Union[str, None] = first_existing_file(_DEFAULT_CONFIG_FILE_LOCATIONS)
@@ -41,10 +41,10 @@ class ConfigFile(BaseSettings):
             path.mkdir()
         return v
 
-    @validator("oauth_path", pre=True)
+    @validator("oauth_path")
     def unpickle_oauth_path(cls, v):
         if v is None:
-            return
+            return v
         path = expand_and_resolve(v)
         if not path.is_file():
             error_message = "Provided OAUTH configuration value must be file."

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -29,7 +29,7 @@ class ConfigFile(BaseSettings):
         env_file: Union[str, None] = first_existing_file(_DEFAULT_CONFIG_FILE_LOCATIONS)
         env_file_encoding = "utf-8"
 
-    @validator("data_path", "log_path")
+    @validator("data_path", "log_path", pre=True)
     def create_paths_if_do_not_exist(cls, v: Path):
         # for key, path in values.items():
         path = expand_and_resolve(v)
@@ -39,7 +39,7 @@ class ConfigFile(BaseSettings):
             )
         elif not path.exists():
             path.mkdir()
-        return v
+        return path
 
     @validator("oauth_path")
     def unpickle_oauth_path(cls, v):

--- a/hydroshare_jupyter_sync/config_setup.py
+++ b/hydroshare_jupyter_sync/config_setup.py
@@ -3,7 +3,7 @@ import pickle
 from pathlib import Path
 from typing import Optional, Union
 from .utilities.pathlib_utils import first_existing_file, expand_and_resolve
-from .models.oauth import OAuthFile, OAuthContents
+from .models.oauth import OAuthFile
 
 _DEFAULT_CONFIG_FILE_LOCATIONS = (
     "~/.config/hydroshare_jupyter_sync/config",

--- a/hydroshare_jupyter_sync/handlers/__init__.py
+++ b/hydroshare_jupyter_sync/handlers/__init__.py
@@ -12,6 +12,7 @@ from ..server import (
     LocalResourceEntityHandler,
     HydroShareResourceEntityHandler,
     WebAppHandler,
+    UsingOAuth,
 )
 
 
@@ -31,6 +32,10 @@ def get_route_handlers(frontend_url, backend_url):
             {"path": str(assets_path)},
         ),
         # "backend"
+        (
+            url_path_join(backend_url, r"/oauth"),
+            UsingOAuth,
+        ),
         (
             url_path_join(backend_url, r"/ws"),
             FileSystemEventWebSocketHandler,

--- a/hydroshare_jupyter_sync/lib/filesystem/fs_map.py
+++ b/hydroshare_jupyter_sync/lib/filesystem/fs_map.py
@@ -169,7 +169,8 @@ class RemoteFSMap(FSMap):
         # NOTE: assumes user if logged in and using standard username, pass auth. Likely should
         # guard in future.
         # get username
-        username = hydroshare._hs_session._session.auth[0]
+        # TODO: Remove
+        # username = hydroshare._hs_session._session.auth[0]
 
         # NOTE: assumes only resources desired for tracking are owned. may not be desirable.
         # get resources the user can edit

--- a/hydroshare_jupyter_sync/models/api_models.py
+++ b/hydroshare_jupyter_sync/models/api_models.py
@@ -7,6 +7,8 @@ from pydantic import (
     validator,
 )
 from typing import List, Union
+from hsclient import Token
+
 from .resource_type_enum import ResourceTypeEnum
 
 
@@ -32,7 +34,7 @@ class StandardCredentials(ModelNoExtra):
 
 class OAuthCredentials(ModelNoExtra):
     client_id: StrictStr = Field(...)
-    token: StrictStr = Field(...)
+    token: Token = ...
 
 
 CredentialTypes = Union[StandardCredentials, OAuthCredentials]

--- a/hydroshare_jupyter_sync/models/oauth.py
+++ b/hydroshare_jupyter_sync/models/oauth.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel
+
+# typing imports
+from typing import Tuple, Union
+
+
+class OAuthContents(BaseModel):
+    access_token: str
+    token_type: str
+    refresh_token: str
+    scope: str
+    expires_in: str
+
+
+class OAuthFile(BaseModel):
+    __root__: Tuple[OAuthContents, str]
+
+    def dict(
+        self,
+        *,
+        include: Union["AbstractSetIntStr", "MappingIntStrAny"] = None,
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny"] = None,
+        by_alias: bool = False,
+        skip_defaults: bool = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False
+    ) -> "DictStrAny":
+        d = super().dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
+        # drop __root__, return only inner model
+        return d["__root__"]

--- a/hydroshare_jupyter_sync/models/oauth.py
+++ b/hydroshare_jupyter_sync/models/oauth.py
@@ -1,19 +1,12 @@
 from pydantic import BaseModel
+from hsclient import Token
 
 # typing imports
 from typing import Tuple, Union
 
 
-class OAuthContents(BaseModel):
-    access_token: str
-    token_type: str
-    refresh_token: str
-    scope: str
-    expires_in: str
-
-
 class OAuthFile(BaseModel):
-    __root__: Tuple[OAuthContents, str]
+    __root__: Tuple[Token, str]
 
     def dict(
         self,

--- a/hydroshare_jupyter_sync/server.py
+++ b/hydroshare_jupyter_sync/server.py
@@ -59,7 +59,7 @@ from .models.api_models import (
     CollectionOfResourceMetadata,
     ResourceFiles,
 )
-from .models.oauth import OAuthContents, OAuthFile
+from .models.oauth import OAuthFile
 from .session_struct import SessionStruct
 from .session import session_sync_struct
 
@@ -195,7 +195,7 @@ class BaseRequestHandler(SessionMixIn, JupyterHandler):  # TODO: will need to ch
         if creds is not None:
             oauth_contents, client_id = creds
             return OAuthCredentials(
-                token=oauth_contents["access_token"], client_id=client_id
+                token=oauth_contents, client_id=client_id
             )
 
 

--- a/hydroshare_jupyter_sync/server.py
+++ b/hydroshare_jupyter_sync/server.py
@@ -193,8 +193,10 @@ class BaseRequestHandler(SessionMixIn, JupyterHandler):  # TODO: will need to ch
         creds = self.settings.get("oauth_path")  # type: OAuthFile
         # implicit None if creds **is** None
         if creds is not None:
-            oauth_contents, client_id= creds.dict()
-            return OAuthCredentials(token=oauth_contents.access_token, client_id=client_id)
+            oauth_contents, client_id = creds
+            return OAuthCredentials(
+                token=oauth_contents["access_token"], client_id=client_id
+            )
 
 
 class HeadersMixIn:
@@ -263,7 +265,8 @@ class UsingOAuth(MutateSessionMixIn, HeadersMixIn, BaseRequestHandler):
     def get(self):
         if self.oauth_creds:
             self.write(self.oauth_creds.dict())
-        self.write(OAuthCredentials(client_id="", token="").dict())
+        else:
+            self.write(OAuthCredentials(client_id="", token="").dict())
 
 
 class LoginHandler(MutateSessionMixIn, HeadersMixIn, BaseRequestHandler):

--- a/hydroshare_jupyter_sync/server.py
+++ b/hydroshare_jupyter_sync/server.py
@@ -194,9 +194,7 @@ class BaseRequestHandler(SessionMixIn, JupyterHandler):  # TODO: will need to ch
         # implicit None if creds **is** None
         if creds is not None:
             oauth_contents, client_id = creds
-            return OAuthCredentials(
-                token=oauth_contents, client_id=client_id
-            )
+            return OAuthCredentials(token=oauth_contents, client_id=client_id)
 
 
 class HeadersMixIn:
@@ -266,7 +264,15 @@ class UsingOAuth(MutateSessionMixIn, HeadersMixIn, BaseRequestHandler):
         if self.oauth_creds:
             self.write(self.oauth_creds.dict())
         else:
-            self.write(OAuthCredentials(client_id="", token="").dict())
+            # TODO: In the future, a model denoting that oauth is not enabled should be returned instead.
+            empty = {
+                "client_id": "",
+                "token": {
+                    "access_token": "",
+                    "token_type": "",
+                },
+            }
+            self.write(OAuthCredentials.parse_obj(empty).dict())
 
 
 class LoginHandler(MutateSessionMixIn, HeadersMixIn, BaseRequestHandler):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-build-backend = "setuptools.build_meta"
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0rc15,==3.*", "setuptools>=40.8.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ PYTHON_REQUIRES = ">=3.7"
 # Package dependency requirements
 REQUIREMENTS = [
     "hs-restclient",  # TODO: remove hs-restclient
-    "hsclient",
+    "hsclient>=0.2.0",
     "jupyterlab",
     "notebook",
     "requests",

--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,20 @@ Maintainer Email: araney@cuahsi.org
 Maintainer Affiliation: CUAHSI
 """
 # TODO: add citation
-import os
-import sys
-import glob
-import shutil
 from pathlib import Path
-import subprocess
-from setuptools import Command, setup, find_packages
-from setuptools.command.install import install
+from setuptools import setup, find_packages
 
 # define package name globally
-PKGNAME = "hydroshare_jupyter_sync"
-VERSION = "0.1.2"
+PKGNAME = "hydroshare_on_jupyter"
+VERSION = "0.2.2"
 
 # define webapp path globally
-here = Path(__file__).resolve().parent.absolute()
+here = Path(__file__).resolve().parent
 webpath = here / "webapp"
+
+# path to pre-built lab-extension
+EXTENSION_NAME = "hydroshare_jupyter_sync"
+LABEXTENSION_PATH = here / EXTENSION_NAME / "labextension"
 
 # Package author information
 AUTHOR = "CUAHSI"
@@ -50,88 +48,27 @@ DEVELOPMENT_REQUIREMENTS = ["pytest", "pytest-tornado"]
 
 SHORT_DESCRIPTION = "A web app and server for syncing files between the local filesystem and HydroShare. Can run as a Jupyter notebook extension."
 
+
 # Long description
 with (Path(__file__).parent / "README.md").open("r") as f:
     LONG_DESCRIPTION = f.read()
 
-
-def run_command(command, cwd):
-    process = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE)
-    for line in process.stdout:
-        sys.stdout.write(line.decode("utf-8"))
-
-
-class build_react(install):
-    def run(self):
-        # build and install the Sync Webapp
-        cmd = ["yarn", "install"]
-        run_command(cmd, cwd=webpath)
-
-        cmd = ["yarn", "build"]
-        run_command(cmd, cwd=webpath)
-
-        # move files to python build dir
-        assets = os.path.join(webpath, "public", "assets")
-        target_path = os.path.join(os.getcwd(), PKGNAME, "assets")
-        if os.path.exists(target_path):
-            shutil.rmtree(target_path)
-        shutil.copytree(assets, target_path)
-
-
-class CleanCommand(Command):
-    """Custom clean command to tidy up the project root."""
-
-    CLEAN_FILES = [
-        "./build",
-        "./dist",
-        "./*.pyc",
-        "./*.tgz",
-        "./*.egg-info",
-        "./webapp/build",
-        "./webapp/node_modules",
-    ]
-
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-
-        for path_spec in self.CLEAN_FILES:
-            # Make paths absolute and relative to this path
-            abs_paths = glob.glob(os.path.normpath(os.path.join(here, path_spec)))
-            for path in [str(p) for p in abs_paths]:
-                if not path.startswith(here):
-                    # Die if path in CLEAN_FILES is absolute
-                    # + outside this directory
-                    raise (ValueError)("%s is not a path inside %s" % (path, here))
-                print("removing %s" % os.path.relpath(path))
-                shutil.rmtree(path)
-
-
-setup(
-    cmdclass={
-        "build_react": build_react,
-        "clean": CleanCommand,
-    },
-    name=PKGNAME,
-    version=VERSION,
-    python_requires=PYTHON_REQUIRES,
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
-    maintainer=MAINTAINER,
-    maintainer_email=MAINTAINER_EMAIL,
-    packages=find_packages(),
-    url="https://github.com/hydroshare/hydroshare_jupyter_sync",
-    license="",
-    description=SHORT_DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type="text/markdown",
-    include_package_data=True,
-    install_requires=REQUIREMENTS,
-    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
-)
+if __name__ == "__main__":
+    setup(
+        name=PKGNAME,
+        version=VERSION,
+        python_requires=PYTHON_REQUIRES,
+        author=AUTHOR,
+        author_email=AUTHOR_EMAIL,
+        maintainer=MAINTAINER,
+        maintainer_email=MAINTAINER_EMAIL,
+        packages=find_packages(),
+        url="https://github.com/hydroshare/hydroshare_jupyter_sync",
+        license="",
+        description=SHORT_DESCRIPTION,
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        include_package_data=True,
+        install_requires=REQUIREMENTS,
+        extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import pytest
+import pickle
 from hydroshare_jupyter_sync.config_setup import ConfigFile, FileNotDirectoryError
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, TemporaryFile
 from pathlib import Path
 
 
@@ -44,3 +45,33 @@ def test_config_using_env_file():
         c = ConfigFile(_env_file=env_file)
         assert str(c.data_path) == str(temp)
         assert str(c.log_path) == str(log)
+
+
+@pytest.fixture
+def oauth_data():
+    return [
+        {
+            "access_token": "some_fake_token",
+            "token_type": "Bearer",
+            "refresh_token": "some_fake_token",
+            "scope": "scope",
+            "expires_in": 2592000,
+        },
+        "some_fake_token",
+    ]
+
+
+@pytest.fixture
+def oauth_file(oauth_data) -> Path:
+
+    filename = ".hs_auth"
+    with TemporaryDirectory() as dir:
+        oauth_path = Path(dir) / filename
+        with open(oauth_path, "wb") as f:
+            pickle.dump(oauth_data, f, protocol=2)
+        yield oauth_path
+
+
+def test_config_oauth(oauth_file, oauth_data):
+    o = ConfigFile(oauth_path=oauth_file)
+    assert o.oauth_path.access_token == oauth_data[0]["access_token"]

--- a/tests/test_oauth_json_model.py
+++ b/tests/test_oauth_json_model.py
@@ -1,0 +1,21 @@
+import pytest
+from hydroshare_jupyter_sync.models.oauth import OAuthFile
+
+
+@pytest.fixture
+def testing_data():
+    return (
+        {
+            "access_token": "some_fake_token",
+            "token_type": "Bearer",
+            "refresh_token": "some_fake_token",
+            "scope": "scope",
+            "expires_in": 2592000,
+        },
+        "some_fake_token",
+    )
+
+
+def test_it_works(testing_data):
+    o = OAuthFile.parse_obj(testing_data)
+    o.dict()[1] == testing_data[1]

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -15,7 +15,7 @@ import { ResourceGrid } from "./components/ResourceGrid";
 import { ResourcePage } from "./components/ResourcePage";
 import { PluginServicesContext } from "./contexts";
 import store from "./store/store";
-import { IDataDirectory } from "./store/sync-api/interfaces";
+import { IDataDirectory, IOAuthCredential } from "./store/sync-api/interfaces";
 import { SnackbarProvider, SnackbarProviderProps } from "notistack";
 import SingleSlide from "./components/SingleSlide";
 import { getJupyterConfigData } from "./utilities/getJupyterConfigData";
@@ -67,6 +67,7 @@ const ReactApp: React.FC<ReactAppProps> = ({ close, docManager }) => {
   const classes = useStyles();
   const [dataDirectory, setDataDirectory] = useState<string>(undefined!);
   const [serverRoot, setServerRoot] = useState<string>("");
+  const [oauth, setOAuth] = useState<IOAuthCredential>();
   const sorterContextValues = useSorterContext();
 
   useEffect(() => {
@@ -74,13 +75,19 @@ const ReactApp: React.FC<ReactAppProps> = ({ close, docManager }) => {
       const configData = await getJupyterConfigData();
 
       const BASE_URL = configData["baseUrl"];
-      const URI = BASE_URL + "syncApi/data_directory";
+      const DATA_DIR_URI = BASE_URL + "syncApi/data_directory";
+      const OAUTH_URI = BASE_URL + "syncApi/oauth";
       const SERVER_ROOT = configData["serverRoot"];
 
-      const res = await fetch(URI);
+      const res = await fetch(DATA_DIR_URI);
       const data: IDataDirectory = await res.json();
       setServerRoot(SERVER_ROOT);
       setDataDirectory(data.data_directory);
+
+      // get if oauth is being used. if it is, store that information and login
+      const usingOAuthRes = await fetch(OAUTH_URI);
+      const oAuthData: IOAuthCredential = await usingOAuthRes.json();
+      setOAuth(oAuthData);
     }
     fetchConfigData();
   }, []);

--- a/webapp/src/components/modals/Dialog.tsx
+++ b/webapp/src/components/modals/Dialog.tsx
@@ -1,26 +1,58 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { DialogActions } from "@material-ui/core";
 import Dialog from "@material-ui/core/Dialog";
 import Button from "@material-ui/core/Button";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
-import { useAppSelector } from "../../store/hooks";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import LoginForm from "./LoginForm";
 import { ICloseWidget } from "../../app";
 import { FormikProps } from "formik";
+import {
+  useUsingOAuthQuery,
+  useOAuthLoginMutation,
+} from "../../store/sync-api";
+import { login } from "../../store/actions";
+import { fileSystemWebSocket } from "../../communication/ws";
 
 export const FormDialog: React.FC<ICloseWidget> = ({ close }) => {
   const loginState = useAppSelector(({ login }) => login.status);
+  const dispatch = useAppDispatch();
+
+  // isFetching will be true for both the first request fired off, as well as subsequent requests.
+  // https://redux-toolkit.js.org/rtk-query/usage/queries#frequently-used-query-hook-return-values
+  const { data, isFetching } = useUsingOAuthQuery();
+  const [loginWithOAuth, _] = useOAuthLoginMutation();
 
   const formRef = useRef<FormikProps<any>>(null);
   const [failedLoginAttempt, setFailedLoginAttempt] = useState<boolean>(false);
+
+  useEffect(() => {
+    async function asyncLogin() {
+      if (data && data.client_id && data.token) {
+        const res = await loginWithOAuth(data).unwrap();
+        // if success, set login to true
+        console.log(res.success);
+
+        if (res.success) {
+          dispatch(login());
+          // push user to home page
+          // history.push("/");
+          // open websocket connection with backend
+          fileSystemWebSocket();
+        }
+      }
+    }
+
+    asyncLogin();
+  }, [data]);
 
   return (
     <div>
       <Dialog
         // Open if use is not logged in
-        open={!loginState}
+        open={!loginState && !isFetching}
         aria-labelledby="form-dialog-title"
       >
         <DialogTitle id="form-dialog-title">Login to HydroShare</DialogTitle>

--- a/webapp/src/store/sync-api/index.ts
+++ b/webapp/src/store/sync-api/index.ts
@@ -9,6 +9,7 @@ import {
   IResourceFilesRequest,
   IResourceFileDownloadRequest,
   IDataDirectory,
+  IOAuthCredential,
 } from "./interfaces";
 import { getBaseUrl } from "../../utilities/getJupyterConfigData";
 
@@ -34,6 +35,17 @@ export const syncApi = createApi({
       // invalidate all tags
       invalidatesTags: ["EndSession", "Resource"],
     }),
+    // login using OAuth
+    oAuthLogin: build.mutation<ISuccess, IOAuthCredential>({
+      query: (creds) => ({
+        url: `login`,
+        params: { _xsrf: getCookie("_xsrf") },
+        method: "POST",
+        body: creds,
+      }),
+      // invalidate all tags
+      invalidatesTags: ["EndSession", "Resource"],
+    }),
     // log user out
     logout: build.mutation<void, void>({
       query: () => ({
@@ -44,6 +56,10 @@ export const syncApi = createApi({
       }),
       // invalidate all tags
       invalidatesTags: ["EndSession", "Resource"],
+    }),
+    // get data directory (i.e. where hydroshare resources are stored locally)
+    usingOAuth: build.query<IOAuthCredential, void>({
+      query: () => "oauth",
     }),
     // get data directory (i.e. where hydroshare resources are stored locally)
     dataDirectory: build.query<IDataDirectory, void>({
@@ -123,6 +139,8 @@ export const {
   useDownloadResourceQuery,
   useDownloadResourceEntityQuery,
   useUploadResourceEntityMutation,
+  useOAuthLoginMutation,
+  useUsingOAuthQuery,
 } = syncApi;
 
 export default syncApi;

--- a/webapp/src/store/sync-api/interfaces.ts
+++ b/webapp/src/store/sync-api/interfaces.ts
@@ -46,3 +46,17 @@ export interface IUserInfo {
 export interface IDataDirectory {
   data_directory: string;
 }
+
+export interface IOAuthCredential {
+  client_id: string;
+  token: IOAuthToken;
+}
+
+export interface IOAuthToken {
+  access_token: string;
+  token_type: string;
+  scope?: string;
+  state?: string;
+  expires_in?: number;
+  refresh_token?: string;
+}


### PR DESCRIPTION
It is desirable to login to HydroShare via OAuth2. The prominent use case for this is automating login to HydroShare on a JupyterHub instance that uses HydroShare OAuth2 for login (for reference, this is how cuahsi's JupyterHub works).

This PR adds the ability to login to HydroShare (via `hsclient`) using OAuth2.

## Additions

- Optional `OAUTH` key added to configuration file. Specify filesystem location of canonical HydroShare OAuth2 pickle (uses pickle protocol 2) file to `OAUTH` key. At runtime, with all configuration keys, `OAUTH` can be specified as an environment variable. See the [`OAuthFile`](https://github.com/aaraney/hydroshare_jupyter_sync/blob/cad9ad7e258543761882892f9e570d2448e5538a/hydroshare_jupyter_sync/models/oauth.py#L8) and [`hsclient.Token`](https://github.com/hydroshare/hsclient/blob/a8152e483a05883c9242b65d0fae2a7b16c47e07/hsclient/oauth2_model.py#L8) pydantic models for canonical HydroShare OAuth2 pickle file content expectations.
- `/syncApi/oauth` endpoint added. Can query without login, to return OAuth2 creds ([`OAuthCredentials`](https://github.com/aaraney/hydroshare_jupyter_sync/blob/cad9ad7e258543761882892f9e570d2448e5538a/hydroshare_jupyter_sync/models/api_models.py#L35)) if they are configured. An empty `OAuthCredentials` model is returned if they are not configured.
- rtk query hooks added to frontend for logging in with OAuth and querying for OAuth creds.

## Removals

-

## Changes

- package renamed to `hydroshare_on_jupyter`
- backend app now follows `jupyter_server` conventions. (see [`jupyter_server`](https://jupyter-server.readthedocs.io/en/latest/))
- backend `LoginHandler` now accepts OAuth2 or standard (username, password) auth.
- package now depends on `hsclient>=0.2.0`
- frontend now queries `/syncApi/oauth` at startup. If OAuth creds were fetched, app will bypass standard username password login and try to login using retrieved OAuth credentials. 

## Todos

- "Rebrand" package using new name, `hydroshare_on_jupyter`. Ref PR and issues that accomplishes this.
- move to `setup.cfg` only package.


