### PR TITLE
Reset package version to 0.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 # define package name globally
 PKGNAME = "hydroshare_on_jupyter"
-VERSION = "0.2.2"
+VERSION = "0.1.0"
 
 # define webapp path globally
 here = Path(__file__).resolve().parent


### PR DESCRIPTION
Given the renaming of the package from `hydroshare_jupyter_sync` to `hydroshare_on_jupyter`, given the number of changes and the upcoming "release", the package version has been reset to `0.1.0` (both python and javascript).

## Changes

- package version has been reset to `0.1.0`

