### PR TITLE
Lazily evaluate present local resources. Drastically lowers changes of timeout

### DIFF
--- a/hydroshare_on_jupyter/fs_events.py
+++ b/hydroshare_on_jupyter/fs_events.py
@@ -17,5 +17,7 @@ class Events(Enum):
     RESOURCE_DOWNLOADED = auto()  # Callable[[ResourceId], None]
     RESOURCE_ENTITY_DOWNLOADED = auto()  # Callable[[ResourceId], None]
     RESOURCE_ENTITY_UPLOADED = auto()  # Callable[[ResourceId], None]
+    RESOURCE_FILES_LISTED = auto()  # Callable[[ResourceId], None]
+    RESOURCE_STATUS = auto()  # Callable[[ResourceId], None]
     # TODO: implement below.
     LOGOUT = auto()  # NOOP

--- a/hydroshare_on_jupyter/lib/filesystem/aggregate_fs_map.py
+++ b/hydroshare_on_jupyter/lib/filesystem/aggregate_fs_map.py
@@ -20,6 +20,16 @@ class AggregateFSMap(IFSMap, IEntityFSMap):
     # IFSMap implementations
 
     @classmethod
+    def create_empty_map(
+        cls, fs_root: Union[Path, str], hydroshare: HydroShare
+    ) -> "AggregateFSMap":
+        # create local and remote map instances
+        remote_map = RemoteFSMap(fs_root, hydroshare)
+        local_map = LocalFSMap(fs_root)
+
+        return cls(local_map=local_map, remote_map=remote_map)
+
+    @classmethod
     def create_map(
         cls, fs_root: Union[Path, str], hydroshare: HydroShare
     ) -> "AggregateFSMap":

--- a/hydroshare_on_jupyter/lib/filesystem/fs_map.py
+++ b/hydroshare_on_jupyter/lib/filesystem/fs_map.py
@@ -177,12 +177,14 @@ class RemoteFSMap(FSMap):
         remote_resources = {
             res.resource_id for res in hydroshare.search(edit_permission=True)
         }
+
         # naively get local resources based on fs_root location and directory name length
         naive_local_resources = set(fs_map._get_resource_ids())
 
         # resources s.t. user is owner and some files from res are local
         users_local_resources = naive_local_resources & remote_resources
 
+        # create hsclient.HydroShare.Resource object for each resource that is naively on the local fs
         res_objs = [
             fs_map._hydroshare.resource(res_id) for res_id in users_local_resources
         ]

--- a/hydroshare_on_jupyter/lib/filesystem/fs_resource_map.py
+++ b/hydroshare_on_jupyter/lib/filesystem/fs_resource_map.py
@@ -1,21 +1,11 @@
 from abc import ABC, abstractmethod
 from collections import UserDict
-from typing import Dict, List, Union
+from typing import List, Union
 from hsclient import Resource
-import hashlib
 from pathlib import Path
 
-
-def compute_file_md5_hexdigest(file: Union[str, Path]) -> str:
-    """Compute a file's md5 hexdigest. Read file as chunks to conserve memory usage."""
-    with open(file, "rb") as f:
-        hash = hashlib.md5()
-        chunk = f.read(8192)
-        while chunk:
-            hash.update(chunk)
-            chunk = f.read(8192)
-
-        return hash.hexdigest()
+# local imports
+from .utilities import compute_file_md5_hexdigest, get_resource_checksums
 
 
 # abstract interfaces
@@ -190,8 +180,4 @@ class RemoteFSResourceMap(FSResourceMap):
         # force resource to re-fetch manifest-md5.txt from hs
         self.resource._parsed_checksums = None
 
-        self.data = {
-            Path(k): v
-            for k, v in self.resource._checksums.items()
-            if k.startswith("data/contents/")
-        }
+        self.data = get_resource_checksums(self.resource)

--- a/hydroshare_on_jupyter/lib/filesystem/utilities.py
+++ b/hydroshare_on_jupyter/lib/filesystem/utilities.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import hashlib
+from hsclient import Resource
+
+# typing imports
+from typing import Dict, Union
+from .types import MD5Hash
+
+
+def get_resource_checksums(resource: Resource) -> Dict[Path, MD5Hash]:
+    """Return dictionary of file path: MD5 checksum for a given HydroShare resource. Only files that
+    are children of 'data/contents/' are included. All file paths are relative to an unspecified
+    root.
+
+    Args:
+        resource (Resource): HydroShare Resource object
+
+    Returns:
+        Dict[Path, MD5Hash]: relative file path as Path, MD5 checksum
+    """
+    return {
+        Path(k): v
+        for k, v in resource._checksums.items()
+        if k.startswith("data/contents/")
+    }
+
+
+def compute_file_md5_hexdigest(file: Union[str, Path]) -> str:
+    """Compute a file's md5 hexdigest. Read file as chunks to conserve memory usage.
+
+    Args:
+        file (Union[str, Path]): path to file
+
+    Returns:
+        str: file's md5 checksum as hex
+    """
+    with open(file, "rb") as f:
+        hash = hashlib.md5()
+        chunk = f.read(8192)
+        while chunk:
+            hash.update(chunk)
+            chunk = f.read(8192)
+
+        return hash.hexdigest()

--- a/hydroshare_on_jupyter/session_sync_event_listeners.py
+++ b/hydroshare_on_jupyter/session_sync_event_listeners.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 # local imports
 from .fs_events import Events
 from .session_struct_interface import ISessionSyncStruct
+from .lib.filesystem.types import ResourceId
 
 
 @dataclass
@@ -12,6 +13,7 @@ class SessionSyncEventListeners(ISessionSyncStruct):
     def setup_event_listeners(self):
         # event listeners
         listeners = [
+            (Events.RESOURCE_FILES_LISTED, self.resource_files_listed),
             (Events.RESOURCE_DOWNLOADED, self.resource_downloaded),
             (Events.RESOURCE_ENTITY_DOWNLOADED, self.resource_entity_downloaded),
             (Events.RESOURCE_ENTITY_UPLOADED, self.resource_uploaded),
@@ -19,11 +21,34 @@ class SessionSyncEventListeners(ISessionSyncStruct):
         for event, listener in listeners:
             self.event_broker.subscribe(event, listener)
 
-    def resource_uploaded(self, resource_id) -> None:
+    def resource_files_listed(self, resource_id: ResourceId) -> None:
+        # check if in local map (resource would also be in remote map)
+        if resource_id in self.aggregate_fs_map.local_map:
+            return
+
+        # check naively for local resource files
+        naive_local_resource_ids = set(
+            self.aggregate_fs_map.local_map._get_resource_ids()
+        )
+        # if the resource is local, add to aggregate map (compute checksums, add to local map and create
+        # fs event listener).
+        if resource_id in naive_local_resource_ids:
+            self._add_resource_to_agg_map_and_create_watcher(resource_id)
+
+            # emit RESOURCE_STATUS signal
+            self.event_broker.dispatch(Events.RESOURCE_STATUS, resource_id)
+
+    def update_remote_resource(self, resource_id: ResourceId) -> None:
+
+        if resource_id in self.aggregate_fs_map.remote_map:
+            # pull updated md5 checksums from HydroShare
+            self.aggregate_fs_map.remote_map.update_resource(resource_id)
+
+    def resource_uploaded(self, resource_id: ResourceId) -> None:
         # pull updated md5 checksums from HydroShare
         self.aggregate_fs_map.remote_map.update_resource(resource_id)
 
-    def resource_downloaded(self, resource_id) -> None:
+    def resource_downloaded(self, resource_id: ResourceId) -> None:
         # if resource already in agg map, just update resource in local map
         if resource_id in self.aggregate_fs_map.local_map:
             self.aggregate_fs_map.local_map.update_resource(resource_id)
@@ -31,7 +56,7 @@ class SessionSyncEventListeners(ISessionSyncStruct):
         else:
             self._add_resource_to_agg_map_and_create_watcher(resource_id)
 
-    def resource_entity_downloaded(self, resource_id) -> None:
+    def resource_entity_downloaded(self, resource_id: ResourceId) -> None:
         # if resource already in agg map, add resource file
         if resource_id in self.aggregate_fs_map.local_map:
             # TODO: `add_resource_file` is not method on `AggregateFSMap`. For now, both local and
@@ -44,7 +69,7 @@ class SessionSyncEventListeners(ISessionSyncStruct):
         else:
             self._add_resource_to_agg_map_and_create_watcher(resource_id)
 
-    def _add_resource_to_agg_map_and_create_watcher(self, resource_id):
+    def _add_resource_to_agg_map_and_create_watcher(self, resource_id: ResourceId):
         self.aggregate_fs_map.add_resource(resource_id)
 
         if resource_id not in self.fs_observers:

--- a/hydroshare_on_jupyter/websocket_handler.py
+++ b/hydroshare_on_jupyter/websocket_handler.py
@@ -49,6 +49,9 @@ class FileSystemEventWebSocketHandler(SessionMixIn, WebSocketHandler):
     def _subscribe_to_events(self):
         session.event_broker.subscribe(Events.STATUS, self._get_resource_status)
         session.event_broker.subscribe(
+            Events.RESOURCE_STATUS, self._get_resource_status
+        )
+        session.event_broker.subscribe(
             Events.RESOURCE_ENTITY_UPLOADED, self._get_resource_status
         )
         session.event_broker.subscribe(
@@ -62,6 +65,9 @@ class FileSystemEventWebSocketHandler(SessionMixIn, WebSocketHandler):
         # TODO: bug lifetime of event_broker not guaranteed. event_broker is destroyed by logout logic
         try:
             session.event_broker.unsubscribe(Events.STATUS, self._get_resource_status)
+            session.event_broker.unsubscribe(
+                Events.RESOURCE_STATUS, self._get_resource_status
+            )
             session.event_broker.unsubscribe(
                 Events.RESOURCE_ENTITY_UPLOADED, self._get_resource_status
             )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 # define package name globally
 PKGNAME = "hydroshare_on_jupyter"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 # define webapp path globally
 here = Path(__file__).resolve().parent


### PR DESCRIPTION
Lazily fill fs aggregate map. local file system is not searched for local resources that an HS user is an editor of until they try to list the files in a specified resource. This drastically decreases start-up time post login and resolves websocket time out issues. For context, websocket timeout were increasingly likely proportional to the number of local resources.

## Changes

- File system map now lazily adds local resources to the map when a resource's files are queried


