### PR TITLE
Fix resource updating issue and downloading entire resource bugs

### DIFF
--- a/hydroshare_on_jupyter/server.py
+++ b/hydroshare_on_jupyter/server.py
@@ -393,7 +393,9 @@ class HydroShareResourceHandler(HeadersMixIn, BaseRequestHandler):
             downloaded_zip = resource.download(temp_dir)
             # unzip resource
             with ZipFile(downloaded_zip, "r") as zr:
-                zr.extractall(self.data_path)
+                # respect HydroShare baggit file structure convention
+                # data_path / resource_id / resource_id / ...
+                zr.extractall(self.data_path / resource_id)
 
         # set instance variable for `on_finish`
         self.resource_id = resource_id

--- a/hydroshare_on_jupyter/session_sync_event_listeners.py
+++ b/hydroshare_on_jupyter/session_sync_event_listeners.py
@@ -56,6 +56,9 @@ class SessionSyncEventListeners(ISessionSyncStruct):
         else:
             self._add_resource_to_agg_map_and_create_watcher(resource_id)
 
+        # emit RESOURCE_STATUS signal
+        self.event_broker.dispatch(Events.RESOURCE_STATUS, resource_id)
+
     def resource_entity_downloaded(self, resource_id: ResourceId) -> None:
         # if resource already in agg map, add resource file
         if resource_id in self.aggregate_fs_map.local_map:
@@ -68,6 +71,9 @@ class SessionSyncEventListeners(ISessionSyncStruct):
 
         else:
             self._add_resource_to_agg_map_and_create_watcher(resource_id)
+
+        # emit RESOURCE_STATUS signal
+        self.event_broker.dispatch(Events.RESOURCE_STATUS, resource_id)
 
     def _add_resource_to_agg_map_and_create_watcher(self, resource_id: ResourceId):
         self.aggregate_fs_map.add_resource(resource_id)

--- a/hydroshare_on_jupyter/websocket_handler.py
+++ b/hydroshare_on_jupyter/websocket_handler.py
@@ -54,12 +54,6 @@ class FileSystemEventWebSocketHandler(SessionMixIn, WebSocketHandler):
         session.event_broker.subscribe(
             Events.RESOURCE_ENTITY_UPLOADED, self._get_resource_status
         )
-        session.event_broker.subscribe(
-            Events.RESOURCE_DOWNLOADED, self._get_resource_status
-        )
-        session.event_broker.subscribe(
-            Events.RESOURCE_ENTITY_DOWNLOADED, self._get_resource_status
-        )
 
     def _unsubscribe_from_events(self):
         # TODO: bug lifetime of event_broker not guaranteed. event_broker is destroyed by logout logic
@@ -70,12 +64,6 @@ class FileSystemEventWebSocketHandler(SessionMixIn, WebSocketHandler):
             )
             session.event_broker.unsubscribe(
                 Events.RESOURCE_ENTITY_UPLOADED, self._get_resource_status
-            )
-            session.event_broker.unsubscribe(
-                Events.RESOURCE_DOWNLOADED, self._get_resource_status
-            )
-            session.event_broker.unsubscribe(
-                Events.RESOURCE_ENTITY_DOWNLOADED, self._get_resource_status
             )
         except AttributeError as e:
             pass

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 # define package name globally
 PKGNAME = "hydroshare_on_jupyter"
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 # define webapp path globally
 here = Path(__file__).resolve().parent


### PR DESCRIPTION
This PR resolve two known issues.

1. Issue when downloading an entire resource from backend. Previously, resources were unzipped to `data_path / resource_id`. They are now, correctly, unzipped to `data_path / resource_id / resource_id`.
2. Issue with resource files being shown as only local, when they are in-sync. This was likely because when a file was downloaded from hydroshare and moved to the correct file-system location, the remote fs resource map had not completed its update causing all files to appear as local.

## Changes

- Fixes unpacking location of entire resource upon download.
- Fixes remote fs resource map race condition, where files might have appeared to only be on the local system.
- websocket handler no longer subscribes to resource downloaded and resource entity downloaded events. Given that the current event system dispatches callbacks sequentially in the order of subscription (works like queue), if the websocket were to have subscribed to these events before the aggregate filesystem (the aggregate filesystem updates itself based off of these events), it was possible to have a false state.
